### PR TITLE
[#1] Implement Zeptoparsec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /lean_packages
+.vscode/tasks.json

--- a/Straume/Bit.lean
+++ b/Straume/Bit.lean
@@ -1,0 +1,50 @@
+namespace Bit
+
+-- Bools don't give us enough type safety, I think;
+-- does Lean have a built-in better alternative?
+inductive Bit : Type where
+  | zero : Bit
+  | one  : Bit
+  deriving DecidableEq, Inhabited
+
+export Bit (zero one)
+
+instance : Repr Bit where
+  reprPrec
+    | zero, _ => "0"
+    | one,  _ => "1"
+
+theorem Nat.div2_lt (h : n ≠ 0) : n / 2 < n := by
+  match n with
+  | 1   => decide
+  | 2   => decide
+  | 3   => decide
+  | n+4 =>
+    rw [Nat.div_eq, if_pos]
+    refine Nat.succ_lt_succ (Nat.lt_trans ?_ (Nat.lt_succ_self _))
+    exact @div2_lt (n+2) (by simp_arith)
+    simp_arith
+
+def toBits : Nat → List Bit
+  | 0 => [zero]
+  | 1 => [one]
+  | n + 2 => 
+    have h₁ : (n + 2) ≠ 0 := by simp_arith
+    toBits ((n + 2) / 2) ++ (if n % 2 = 0 then [zero] else [one])
+  termination_by _ n => n
+  decreasing_by exact Nat.div2_lt h₁;
+
+def pad (n : Nat) (bs : List Bit) : List Bit :=
+  let l := bs.length
+  if l >= n then bs else List.replicate (n - l) zero ++ bs
+
+def uint8ToBits (u : UInt8) : List Bit :=
+  pad 8 $ toBits $ UInt8.toNat u
+
+def byteArrayToBits (ba : ByteArray) : List Bit :=
+  List.join $ List.map uint8ToBits $ ByteArray.toList ba
+
+def List.extract (l : List α) (b : Nat) (e : Nat) : List α :=
+  if b > e then l else
+    let lₐ := l.drop b
+    lₐ.take (e - b)

--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -1,0 +1,53 @@
+namespace Iterator
+
+
+class HasTokens (α : Type _) (β : Type _) where
+  tokens : α → List β
+  push : α → β -> α
+
+instance : HasTokens String Char where
+  tokens := String.data
+  push := String.push
+
+export HasTokens (tokens push)
+
+
+
+structure Iterator (α : Type) where
+  s : α
+  i : Nat
+  deriving DecidableEq, Repr
+
+def iter (s : α) : Iterator α :=
+  ⟨s, 0⟩
+
+
+class Iterable (α : Type) where
+  length : α -> Nat
+  hasNext : Iterator α -> Bool
+  next : Iterator α -> Iterator α
+  extract : Iterator α → Iterator α → α
+
+export Iterable (length hasNext next extract)
+
+
+instance : Iterable String where
+  length s := s.length 
+  hasNext | ⟨s, i⟩ => i < s.endPos.byteIdx
+  next | ⟨s, i⟩ => ⟨s, (s.next ⟨i⟩).byteIdx⟩
+  extract
+    | ⟨s₁, b⟩, ⟨s₂, e⟩ =>
+      if s₁ ≠ s₂ || b > e then ""
+      else s₁.extract ⟨b⟩ ⟨e⟩
+
+
+
+def curr (β : Type _) [HasTokens α β] [Inhabited β] (it: Iterator α) [Iterable α] : β :=
+  let ts := tokens it.s
+  match ts.get? it.i with
+    | some curr! => curr!
+    | none       => default -- unreachable: pos shouldn't increase if ¬s.hasNext
+
+def forward [Iterable α] : Iterator α → Nat → Iterator α
+  | it, 0   => it
+  | it, n+1 => forward (next it) n

--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -1,3 +1,6 @@
+import Straume.Bit
+open Bit
+
 namespace Iterator
 
 instance : DecidableEq ByteArray
@@ -20,6 +23,9 @@ instance : HasTokens ByteArray UInt8 where
   tokens := ByteArray.toList
   push := ByteArray.push
 
+instance : HasTokens ByteArray Bit where
+  tokens ba := List.join $ List.map uint8ToBits $ ByteArray.toList ba
+  push := sorry -- unclear semantics: make into a whole UInt8?
 
 structure Iterator (α : Type) where
   s : α

--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -1,16 +1,24 @@
 namespace Iterator
 
+instance : DecidableEq ByteArray
+  | a, b => match decEq a.data b.data with
+    | isTrue h₁  => isTrue $ congrArg ByteArray.mk h₁
+    | isFalse h₂ => isFalse $ fun h => by cases h; exact (h₂ rfl)
+
 
 class HasTokens (α : Type _) (β : Type _) where
   tokens : α → List β
   push : α → β -> α
 
+export HasTokens (tokens push)
+
 instance : HasTokens String Char where
   tokens := String.data
   push := String.push
 
-export HasTokens (tokens push)
-
+instance : HasTokens ByteArray UInt8 where
+  tokens := ByteArray.toList
+  push := ByteArray.push
 
 
 structure Iterator (α : Type) where
@@ -40,6 +48,14 @@ instance : Iterable String where
       if s₁ ≠ s₂ || b > e then ""
       else s₁.extract ⟨b⟩ ⟨e⟩
 
+instance : Iterable ByteArray where
+  length s := s.size
+  hasNext | ⟨s, i⟩ => i < s.size
+  next | ⟨s, i⟩ => ⟨s, i+1⟩
+  extract
+    | ⟨s₁, b⟩, ⟨s₂, e⟩ =>
+      if s₁ ≠ s₂ || b > e then default
+      else s₁.extract b e
 
 
 def curr (β : Type _) [HasTokens α β] [Inhabited β] (it: Iterator α) [Iterable α] : β :=

--- a/Straume/Zeptoparsec.lean
+++ b/Straume/Zeptoparsec.lean
@@ -1,1 +1,188 @@
+import Straume.Iterator
+open Iterator
+
+/-
+
+To make Zeptoparsec work on another type γ, define all the necessary
+scaffolding in Iterator.lean, currently:
+- instance Iterable γ
+- instance HasTokens γ μ, where μ is the type of the underlying elements of γ
+
+-/
+
+/- TODO: somehow make most of σ's implicit -/
+
 namespace Zeptoparsec
+
+variable (σ : Type) [Iterable σ] [Inhabited σ] [DecidableEq σ] [DecidableEq ε] [HasTokens σ ε] [Inhabited ε]
+
+namespace Parsec
+inductive ParseResult (α: Type) where
+  | success (pos : Iterator σ) (res : α)
+  | error (pos : Iterator σ) (err : String)
+  deriving Repr
+
+def Parsec (α : Type) : Type := Iterator σ → ParseResult σ α
+
+end Parsec
+
+namespace Parsec
+open ParseResult
+
+instance (α : Type) : Inhabited (Parsec σ α) :=
+  ⟨λ it => error it ""⟩
+
+@[inline]
+protected def pure (a : α) : Parsec σ α := λ it =>
+ success it a
+
+@[inline]
+def bind {α β : Type} (f : Parsec σ α) (g : α → Parsec σ β) : Parsec σ β := λ it =>
+  match f it with
+  | success rem a => g a rem
+  | error pos msg => error pos msg
+
+instance : Monad (Parsec σ) :=
+  { pure := Parsec.pure σ, bind := bind σ }
+
+@[inline]
+def fail (msg : String) : Parsec σ α := fun it =>
+  error it msg
+
+@[inline]
+def orElse (p : Parsec σ α) (q : Unit → Parsec σ α) : Parsec σ α := fun it =>
+  match p it with
+  | success rem a => success rem a
+  | error rem err =>
+    if it = rem then q () it else error rem err
+
+@[inline]
+def attempt (p : Parsec σ α) : Parsec σ α := λ it =>
+  match p it with
+  | success rem res => success rem res
+  | error _ err => error it err
+
+instance : Alternative (Parsec σ) :=
+{ failure := fail σ "", orElse := orElse σ }
+
+def expectedEndOfInput := "expected end of input"
+
+@[inline]
+def eof : Parsec σ Unit := fun it =>
+  if Iterable.hasNext it then
+    error it expectedEndOfInput
+  else
+    success it ()
+
+@[inline]
+partial def manyCore (p : Parsec σ α) (acc : Array α) : Parsec σ $ Array α :=
+  (do manyCore p (acc.push $ ←p))
+  <|> pure acc
+
+@[inline]
+def many (p : Parsec σ α) : Parsec σ $ Array α := manyCore σ p #[]
+
+@[inline]
+def many1 (p : Parsec σ α) : Parsec σ $ Array α := do manyCore σ p #[←p]
+
+@[inline]
+partial def manyCharsCore (p : Parsec σ ε) (acc : σ) : Parsec σ σ :=
+  (do manyCharsCore p (push acc $ ←p))
+  <|> pure acc
+
+-- Parses zero or more occurrences
+@[inline]
+def manyChars (p : Parsec σ ε) : Parsec σ σ := manyCharsCore σ p default
+
+-- Parses one or more occurrences
+@[inline]
+def many1Chars (p : Parsec σ ε) : Parsec σ σ := do
+  manyCharsCore σ p $ push default (←p)
+
+def pstring (s : σ) : Parsec σ σ := λ it =>
+  let substr := extract it (forward it $ length s)
+  if substr = s then
+    success (forward it $ length s) substr
+  else
+    -- error it s!"expected: {s}" -- TODO
+    error it s!"expected something else"
+
+@[inline]
+def skipString (s : σ) : Parsec σ Unit := pstring σ s *> pure ()
+
+def unexpectedEndOfInput := "unexpected end of input"
+
+@[inline]
+def anyChar : Parsec σ ε := λ it =>
+  if hasNext it
+  then success (next it) $ curr ε it
+  else error it unexpectedEndOfInput
+
+@[inline]
+def pchar (c : ε) : Parsec σ ε := attempt σ do
+  -- if (←anyChar σ) = c then pure c else fail σ s!"expected: '{c}'" -- TODO
+  if (←anyChar σ) = c then pure c else fail σ s!"expected some other char"
+
+@[inline]
+def skipChar (c : ε) : Parsec σ Unit := pchar σ c *> pure ()
+
+@[inline]
+def satisfy (p : ε → Bool) : Parsec σ ε := attempt σ do
+  let c ← anyChar σ
+  if p c then return c else fail σ "condition not satisfied"
+
+@[inline]
+def notFollowedBy (p : Parsec σ α) : Parsec σ Unit := λ it =>
+  match p it with
+  | success _ _ => error it ""
+  | error _ _ => success it ()
+
+@[inline]
+def peek? : Parsec σ (Option ε) := fun it =>
+  if hasNext it then
+    success it $ curr ε it
+  else
+    success it none
+
+@[inline]
+def peek! : Parsec σ ε := do
+  let some c ← peek? σ | fail σ unexpectedEndOfInput
+  return c
+
+@[inline]
+def skip : Parsec σ Unit := fun it =>
+  success (next it) ()
+
+-- String-specific
+
+@[inline]
+def digit : Parsec String Char := attempt String do
+  let c ← anyChar String
+  if '0' ≤ c ∧ c ≤ '9' then return c else fail String s!"digit expected"
+
+@[inline]
+def hexDigit : Parsec String Char := attempt String do
+  let c ← anyChar String
+  if ('0' ≤ c ∧ c ≤ '9')
+   ∨ ('a' ≤ c ∧ c ≤ 'a')
+   ∨ ('A' ≤ c ∧ c ≤ 'A') then return c else fail String s!"hex digit expected"
+
+@[inline]
+def asciiLetter : Parsec String Char := attempt String do
+  let c ← anyChar String
+  if ('A' ≤ c ∧ c ≤ 'Z') ∨ ('a' ≤ c ∧ c ≤ 'z') then return c else fail String s!"ASCII letter expected"
+
+partial def skipWs (it : Iterator String) : Iterator String :=
+  if hasNext it then
+    let c := curr Char it
+    if c = '\u0009' ∨ c = '\u000a' ∨ c = '\u000d' ∨ c = '\u0020' then
+      skipWs $ next it
+    else
+      it
+  else
+   it
+
+@[inline]
+def ws : Parsec String Unit := fun it =>
+  success (skipWs it) ()
+end Parsec

--- a/Straume/Zeptoparsec.lean
+++ b/Straume/Zeptoparsec.lean
@@ -5,8 +5,7 @@ open Iterator
 
 To make Zeptoparsec work on another type γ, define all the necessary
 scaffolding in Iterator.lean, currently:
-- instance Iterable γ
-- instance HasTokens γ μ, where μ is the type of the underlying elements of γ
+- instance Iterable γ μ, where μ is the type that γ semantically consists of
 
 -/
 
@@ -14,7 +13,7 @@ scaffolding in Iterator.lean, currently:
 
 namespace Zeptoparsec
 
-variable (σ : Type) [Iterable σ] [Inhabited σ] [DecidableEq σ] [DecidableEq ε] [HasTokens σ ε] [Inhabited ε]
+variable (σ : Type) [Iterable σ ε] [Inhabited σ] [DecidableEq σ] [DecidableEq ε] [Inhabited ε]
 
 namespace Parsec
 inductive ParseResult (α: Type) where
@@ -115,7 +114,7 @@ def unexpectedEndOfInput := "unexpected end of input"
 @[inline]
 def anyChar : Parsec σ ε := λ it =>
   if hasNext it
-  then success (next it) $ curr ε it
+  then success (next it) $ curr it
   else error it unexpectedEndOfInput
 
 @[inline]
@@ -140,7 +139,7 @@ def notFollowedBy (p : Parsec σ α) : Parsec σ Unit := λ it =>
 @[inline]
 def peek? : Parsec σ (Option ε) := fun it =>
   if hasNext it then
-    success it $ curr ε it
+    success it $ curr it
   else
     success it none
 
@@ -174,7 +173,7 @@ def asciiLetter : Parsec String Char := attempt String do
 
 partial def skipWs (it : Iterator String) : Iterator String :=
   if hasNext it then
-    let c := curr Char it
+    let c := curr it
     if c = '\u0009' ∨ c = '\u000a' ∨ c = '\u000d' ∨ c = '\u0020' then
       skipWs $ next it
     else


### PR DESCRIPTION
Problem: we don't have even a simplistic parser.

Solution: reimplemented Parsec.lean together with scaffolding and utilities (`Iterator` structure, `Iterable` class, `Bit` inductive) that lets it work on:
- `String` → `Char`
- `ByteArray` → `UInt8`
- `List Bit` → `Bit`

## Related issues
Follows #1 