### PR TITLE
[#1][#4] Write Zeptoparsec tests

### DIFF
--- a/Straume/Bit.lean
+++ b/Straume/Bit.lean
@@ -14,6 +14,12 @@ instance : Repr Bit where
     | zero, _ => "0"
     | one,  _ => "1"
 
+instance : ToString Bit where
+  toString
+    | zero => "0"
+    | one => "1"
+
+
 theorem Nat.div2_lt (h : n ≠ 0) : n / 2 < n := by
   match n with
   | 1   => decide

--- a/Straume/Bit.lean
+++ b/Straume/Bit.lean
@@ -1,5 +1,12 @@
 namespace Bit
 
+inductive Endian where
+  | big    : Endian
+  | little : Endian
+  deriving Repr, DecidableEq, Inhabited
+
+export Endian (big little)
+
 -- Bools don't give us enough type safety, I think;
 -- does Lean have a built-in better alternative?
 inductive Bit : Type where
@@ -19,7 +26,6 @@ instance : ToString Bit where
     | zero => "0"
     | one => "1"
 
-
 theorem Nat.div2_lt (h : n ≠ 0) : n / 2 < n := by
   match n with
   | 1   => decide
@@ -31,12 +37,12 @@ theorem Nat.div2_lt (h : n ≠ 0) : n / 2 < n := by
     exact @div2_lt (n+2) (by simp_arith)
     simp_arith
 
-def toBits : Nat → List Bit
+def natToBits : Nat → List Bit
   | 0 => [zero]
   | 1 => [one]
   | n + 2 => 
     have h₁ : (n + 2) ≠ 0 := by simp_arith
-    toBits ((n + 2) / 2) ++ (if n % 2 = 0 then [zero] else [one])
+    natToBits ((n + 2) / 2) ++ (if n % 2 = 0 then [zero] else [one])
   termination_by _ n => n
   decreasing_by exact Nat.div2_lt h₁;
 
@@ -45,7 +51,7 @@ def pad (n : Nat) (bs : List Bit) : List Bit :=
   if l >= n then bs else List.replicate (n - l) zero ++ bs
 
 def uint8ToBits (u : UInt8) : List Bit :=
-  pad 8 $ toBits $ UInt8.toNat u
+  pad 8 $ natToBits $ UInt8.toNat u
 
 def byteArrayToBits (ba : ByteArray) : List Bit :=
   List.join $ List.map uint8ToBits $ ByteArray.toList ba
@@ -54,3 +60,16 @@ def List.extract (l : List α) (b : Nat) (e : Nat) : List α :=
   if b > e then l else
     let lₐ := l.drop b
     lₐ.take (e - b)
+
+-- Interprets a `List Bit` as a `Nat`, taking `Endian`ness into consideration.
+def bitsToNat (l: List Bit) (en : Endian := big) : Nat :=
+  let rec go
+    | [], acc => acc
+    | b :: bs, acc => go bs $ acc * 2 + (if b = zero then 0 else 1)
+  let bits := if en = big then l else List.reverse l
+  go bits default
+
+-- Takes first `n` elems of the `List Bit` and interprets them as a `Nat`.
+-- Returns `none` if the list is shorter than `n`.
+def someBitsToNat? (n : Nat) (l: List Bit) (en : Endian := big) : Option Nat :=
+  if n > l.length || n = 0 then .none else .some $ bitsToNat (l.take n) en

--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -3,6 +3,16 @@ open Bit
 
 namespace Iterator
 
+/-
+  We implement a `Repr` instance for `ByteArray` instead of a `ToString`
+  instance for `Iterator α`. At this point, this is a deliberate choice:
+  it's possible we might want to write ToString instances to only show
+  the "remaining" part of the iterator, i.e. a slice of s from i to the end.
+
+  `Repr ByteArray`, however, we need for debug.
+  TODO?
+-/
+
 instance : DecidableEq ByteArray
   | a, b => match decEq a.data b.data with
     | isTrue h₁  => isTrue $ congrArg ByteArray.mk h₁

--- a/Tests/Zeptoparsec.lean
+++ b/Tests/Zeptoparsec.lean
@@ -1,0 +1,71 @@
+import LSpec
+import Straume.Iterator
+import Straume.Zeptoparsec
+import Straume.Bit
+
+open Iterator
+open Zeptoparsec
+open ParseResult
+
+def isSuccess : ParseResult α β → Bool
+  | success _ _ => true
+  | error _ _ => false
+
+def const : α → β → α
+  | a, _ => a
+
+-- String parser tests
+
+def srcStr : Iterator String := iter "This is a test string of 39 characters."
+
+-- This is a general, non-string-specific test, but we place it here to
+-- use the iterator and still have the rest of the tests semi-organized
+def monadTest : TestSeq :=
+  let t := Zeptoparsec.pure 'T' $ next srcStr
+  test "Zeptoparsec.pure works" (anyChar srcStr = t) $
+  test "Zeptoparsec.bind works" $
+    (pstring "T" >>= const (return 'T')) srcStr = t
+
+#lspec monadTest
+
+def someCharsTest : TestSeq :=
+  let pRes := someChars anyChar 4 srcStr
+  test "someChars parses successfully" (isSuccess pRes) $ match pRes with
+    | success pos res =>
+      test s!"First 4 chars of '{srcStr.s}' is 'This'" ("This" = res) $
+      test "Iterator now points to position 4" (4 = pos.i)
+    | error _ _ => test "Unreachable" false
+
+#lspec someCharsTest
+
+def asciiTest : TestSeq :=
+  let expectedPrefix := "This is a test string of "
+  let expected := Zeptoparsec.pure expectedPrefix $ forward srcStr 25
+  let letterOrSpace := orElse asciiLetter (fun _ => pchar ' ')
+  let afterLetters := manyChars letterOrSpace srcStr
+  test "Letter OR space prefix" (expected = afterLetters) $
+  test "Next 2 chars are digits" $
+    many1Chars digit (deparse afterLetters) =
+    someChars anyChar 2 (deparse expected)
+
+#lspec asciiTest
+
+-- ByteArray parser tests
+
+-- List Bit parser tests
+
+open Bit
+
+def srcBits : Iterator (List Bit) := iter $ pad 10 $ natToBits 43
+
+def manyRepsTest : TestSeq :=
+  test "We can parse out groups of max 3 bits" $
+    isSuccess $ many (someChars anyChar 3) srcBits
+
+#lspec manyRepsTest
+
+def main : IO UInt32 := do
+  let _ ← lspec monadTest
+  let _ ← lspec someCharsTest
+  let _ ← lspec asciiTest
+  lspec manyRepsTest

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,8 +3,15 @@ open Lake DSL
 
 package Straume
 
+require LSpec from git
+  "https://github.com/yatima-inc/LSpec.git" @ "3b759f6e7798fdb6b17ae83ea060cd34e89b7e91"
+
 @[defaultTarget]
 lean_exe straume {
   supportInterpreter := true
   root := "Main"
 }
+
+-- Tests
+
+lean_exe Tests.Zeptoparsec


### PR DESCRIPTION
Problem: no Zeptoparsec tests.

Solution: added some tests for string-specific stuff and some more for generic combinators.
Added some Bit utility and some more combinators while we're at it.

## Related issues

Closes #4 
Follows #1