### PR TITLE
bumping lspec and toolchain

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,4 +19,4 @@ jobs:
       - name: build LSpec binary
         run: lake build lspec
       - name: run LSpec
-        run: ./lean_packages/LSpec/build/bin/lspec
+        run: lake exe lspec

--- a/Straume/Avots.lean
+++ b/Straume/Avots.lean
@@ -73,7 +73,7 @@ class Avots (m : Type u → Type v)
   parse : p v v → m s → m (v × s)
   parseN (t : Type u → Type u) : Nat → p v v → m s → m (t v × s)
   parseList := parseN List
-  parseArr := parseN Array
+  parseArr := parseN Arr
   chunkLength : m v → m (Nat × v)
 
 -- structure Greater (α : Type) where

--- a/Straume/Avots.lean
+++ b/Straume/Avots.lean
@@ -73,7 +73,7 @@ class Avots (m : Type u → Type v)
   parse : p v v → m s → m (v × s)
   parseN (t : Type u → Type u) : Nat → p v v → m s → m (t v × s)
   parseList := parseN List
-  parseArr := parseN Arr
+  parseArr := parseN Array
   chunkLength : m v → m (Nat × v)
 
 -- structure Greater (α : Type) where

--- a/Tests/Zeptoparsec.lean
+++ b/Tests/Zeptoparsec.lean
@@ -58,6 +58,7 @@ def manyRepsTest : TestSeq :=
     isSuccess $ many (someChars anyChar 3) srcBits
 
 def main := lspecIO $
-  manyRepsTest
-  ++ monadTest
+  monadTest
+  ++ someCharsTest
   ++ asciiTest
+  ++ manyRepsTest

--- a/Tests/Zeptoparsec.lean
+++ b/Tests/Zeptoparsec.lean
@@ -9,6 +9,8 @@ open Straume.Iterator
 open Zeptoparsec
 open ParseResult
 
+open LSpec
+
 def isSuccess : ParseResult α β → Bool
   | success _ _ => true
   | error _ _ => false
@@ -25,8 +27,6 @@ def monadTest : TestSeq :=
   test "Zeptoparsec.bind works" $
     (pstring "T" >>= const (return 'T')) srcStr = t
 
-#lspec monadTest
-
 def someCharsTest : TestSeq :=
   let pRes := someChars anyChar 4 srcStr
   test "someChars parses successfully" (isSuccess pRes) $ match pRes with
@@ -34,8 +34,6 @@ def someCharsTest : TestSeq :=
       test s!"First 4 chars of '{srcStr.s}' is 'This'" ("This" = res) $
       test "Iterator now points to position 4" (4 = pos.i)
     | error _ _ => test "Unreachable" false
-
-#lspec someCharsTest
 
 def asciiTest : TestSeq :=
   let expectedPrefix := "This is a test string of "
@@ -46,8 +44,6 @@ def asciiTest : TestSeq :=
   test "Next 2 chars are digits" $
     many1Chars digit (deparse afterLetters) =
     someChars anyChar 2 (deparse expected)
-
-#lspec asciiTest
 
 -- ByteArray parser tests
 
@@ -61,10 +57,7 @@ def manyRepsTest : TestSeq :=
   test "We can parse out groups of max 3 bits" $
     isSuccess $ many (someChars anyChar 3) srcBits
 
-#lspec manyRepsTest
-
-def main : IO UInt32 := do
-  let _ ← lspec monadTest
-  let _ ← lspec someCharsTest
-  let _ ← lspec asciiTest
-  lspec manyRepsTest
+def main := lspecIO $
+  manyRepsTest
+  ++ monadTest
+  ++ asciiTest

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,9 +4,7 @@ open Lake DSL
 package Straume
 
 require LSpec from git
-  "https://github.com/yatima-inc/LSpec.git" @ "3b759f6e7798fdb6b17ae83ea060cd34e89b7e91"
-require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git" @ "8f609e0ed826dde127c8bc322cb6f91c5369d37a"
+  "https://github.com/yatima-inc/LSpec.git" @ "77fc51697abeff937ffd20d2050723dc0fa1c8c0"
 
 @[defaultTarget]
 lean_exe straume {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-11
+leanprover/lean4:nightly-2022-07-31


### PR DESCRIPTION
* Drop mathlib dependency since it's not being used anywhere
* Update CI pipeline with new Lake command
* Drop `#lspec` tests since we're building the test file as a binary anyways
* Properly run all tests in the `main` function in a way that errors are propagated
* Bump LSpec version
* Bump the Lean toolchain