### PR TITLE
Bump YatimaStdLib dependency, group tests

### DIFF
--- a/Straume/Iterator.lean
+++ b/Straume/Iterator.lean
@@ -1,7 +1,5 @@
 import YatimaStdLib
 
-open ByteArray
-
 namespace Straume.Iterator
 universe u
 
@@ -21,7 +19,7 @@ instance : DecidableEq ByteArray
     | isFalse h₂ => isFalse $ fun h => by cases h; exact (h₂ rfl)
 
 instance : Repr ByteArray where
-  reprPrec ba _ := toString ba
+  reprPrec ba _ := ba.toString
 
 structure Iterator (α : Type u) where
   s : α
@@ -85,7 +83,7 @@ instance : Iterable (List Bit) Bit where
   curr | ⟨s, i⟩ => let i' := if i < s.length then i else s.length - 1
       -- pos shouldn't increase if ¬s.hasNext, but it's possible to construct
       -- such an iterator manually, so we have to return the last byte.
-    s.get! i'
+    if s.isEmpty then default else s.get! i'
 
 def forward [Iterable α β] : Iterator α → Nat → Iterator α
   | it, 0   => it

--- a/Tests/Iterator.lean
+++ b/Tests/Iterator.lean
@@ -6,10 +6,9 @@ import Straume.Iterator
 
 open LSpec
 open Straume.Iterator
-open ByteArray hiding toList
 
 def str : Iterator String := iter "This is a test string of 39 characters."
-def bits : Iterator (List Bit) := iter $ pad 10 $ natToBits 43
+def bits : Iterator (List Bit) := iter $ Bit.listPad 10 $ Nat.toBits 43
 def emptyBA : Iterator ByteArray := iter default
 
 -- A helper function to turn any `Iterator` to `List` and back again,
@@ -21,43 +20,42 @@ private def lrt
 def listsTest :=
   let rtstr := "There and back again"
   let rtba := List.toByteArray [42, 10, 3]
-  let rtbits := natToBits 10
-  test "toList/fromList roundtrip, strings" (fromList (toList rtstr) = rtstr) $
-  test "toList/fromList roundtrip, strings" (fromList (toList rtba) = rtba) $
-  test "toList/fromList roundtrip, strings" (fromList (toList rtbits) = rtbits)
+  let rtbits := Nat.toBits 10
+  group "toList/fromList roundtrip" $
+    test "strings" (fromList (toList rtstr) = rtstr) $
+    test "bytearray" (fromList (toList rtba) = rtba) $
+    test "bits" (fromList (toList rtbits) = rtbits)
 
 def extractTest
   (tdesc : String) (it : Iterator α)
     [Iterable α β] [Inhabited α] [DecidableEq α] : TestSeq :=
-  test (tdesc ++ ", extracting 0↔0: empty") (extract it it = default) $
-  test (tdesc ++ ", extracting 0↔4: four symbols")
-    (extract it { it with i := 4 } = lrt it.s (List.take 4)) $
-  test (tdesc ++ ", extracting 4↔8: four symbols")
-    (extract { it with i := 4 } { it with i := 8 } =
-      lrt it.s (List.take 4 ∘ List.drop 4)) $
-  test (tdesc ++ ", extracting 0↔n, n > size: returns the whole string") $
-    extract it {it with i := 100} = it.s
+  group s!"{tdesc}, extracting" $
+    test "0↔0: empty" (extract it it = default) $
+    test "0↔4: four symbols"
+      (extract it { it with i := 4 } = lrt it.s (List.take 4)) $
+    test "4↔8: four symbols"
+      (extract { it with i := 4 } { it with i := 8 } =
+        lrt it.s (List.take 4 ∘ List.drop 4)) $
+    test "0↔n, n > size: returns the whole string" $
+      extract it {it with i := 100} = it.s
 
 def forwardTest
   (tdesc : String) (it : Iterator α) [Iterable α β]
     [DecidableEq α] [DecidableEq β] [Inhabited α] [Inhabited β] : TestSeq :=
   let last := if it.s = default then default else (toList it.s).getLast!
-  test (tdesc ++ ", no forwards past the edge")
-    (curr (forward it 100) = last) $
-  test (tdesc ++ ", manual going past the edge returns last char") $
-    curr ({ it with i := 100 }) = last
-
-def singletonTest
-  (tdesc : String) (it : Iterator α)
-    [Iterable α β] [DecidableEq β] [Inhabited β] : TestSeq :=
-  test (tdesc ++ ", hasNext when only one element") $ hasNext it
+  group s!"{tdesc}, forwarding" $
+    test "no forwards past the edge"
+      (curr (forward it 100) = last) $
+    test "manual going past the edge returns last char" $
+      curr ({ it with i := 100 }) = last
 
 def emptyTest
   (tdesc : String) (it : Iterator α)
     [Iterable α β] [DecidableEq β] [Inhabited β] : TestSeq :=
-  test (tdesc ++ ", no hasNext on empty iterator") (hasNext it = false) $
-  test (tdesc ++ ", current elem of empty iterator = default") $
-    curr it = default
+  group s!"{tdesc}, empty" $
+    test "no hasNext on empty iterator" (hasNext it = false) $
+    test "current elem of empty iterator = default" $
+      curr it = default
 
 def main := lspecIO $
   listsTest ++
@@ -68,9 +66,10 @@ def main := lspecIO $
   forwardTest "String" str ++
   forwardTest "List Bit" str ++
 
-  singletonTest "String" (iter ".") ++
-  singletonTest "List Bit" (iter [Bit.one]) ++
-  singletonTest "ByteArray" (iter $ List.toByteArray [42]) ++
+  group "hasNext when only one element" (
+    test "String" (hasNext $ iter ".") $
+    test "List Bit" (hasNext $ iter [Bit.one]) $
+    test "ByteArray" (hasNext $ iter $ List.toByteArray [42])) ++
 
   emptyTest "String" (iter "") ++
   emptyTest "List Bit" ((iter []) : Iterator (List Bit)) ++

--- a/Tests/Zeptoparsec.lean
+++ b/Tests/Zeptoparsec.lean
@@ -6,8 +6,6 @@ import Straume.Iterator
 import Straume.Zeptoparsec
 import Straume.Combinators
 
-open ByteArray
-
 open Straume.Combinators
 open Straume.Iterator
 open Zeptoparsec
@@ -55,7 +53,7 @@ def asciiTest : TestSeq :=
 
 open Bit
 
-def srcBits : Iterator (List Bit) := iter $ pad 10 $ natToBits 43
+def srcBits : Iterator (List Bit) := iter $ listPad 10 $ Nat.toBits 43
 
 def manyRepsTest : TestSeq :=
   test "We can parse out groups of max 3 bits" $

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,7 +6,7 @@ package Straume
 lean_lib Straume
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "876d29cb6f8011119a74712de7cb86280e408e3b"
+  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "cbf5cd7c098c4369d93b9b8399a323bf0a28c107"
 
 require LSpec from git
   "https://github.com/yatima-inc/LSpec.git" @ "9c9f3cc9f3148c1b2d6071a35e54e4c5392373b7"


### PR DESCRIPTION
Problem: we need to address some namespace changes regarding Bit type in YatimaStdLib. Also, groups were introduced in LSpec ages ago, but we're still not using them.

Solution: bumped YatimaStdLib dependency and fixed stuff broken by it. Also grouped Iterator tests, mostly based on the type but sometimes on semantics.